### PR TITLE
feat: Output filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ TFE_ADDRESS=<ADDRESS> TFE_TOKEN=<TOKEN> ./camelot scrape tfc
 All scraping commands accept the following flags:
 * `-v`: verbose mode
 * `-o`: output format, could be `json`, `yaml` or `text` (`text` is default)
+* `-f`: report filter (this flag can be repeated multiple times), supported expressions are: `id=<ID>`, `kind=<RESOURCE_KIND>`, `parent.kind=<PARENT_KIND>`, `parent.id=<ID>`, `status=<STATUS>[,<STATUS1>]`, `version=<VERSION>`. For example: `camelot scrape tfc -f kind=tfc-workspace -f parent.kind=tfc-org -f parent.id=my-infra -f status=warning,critical -f version=0.13.5`.
 
 ## Contributing
 Contributions and ideas are welcome! Please don't hesitate to open an issue, join our [gitter chat room](https://gitter.im/chanzuckerberg/camelot), or send a pull request.

--- a/cmd/scrape-aws.go
+++ b/cmd/scrape-aws.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/chanzuckerberg/camelot/pkg/printer"
 	scraper "github.com/chanzuckerberg/camelot/pkg/scraper/aws"
+	"github.com/chanzuckerberg/camelot/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -61,7 +62,7 @@ func scrape(cmd *cobra.Command, args []string) error {
 			logrus.Errorf("failed to scrape resources for profile %s: %s", profile, err.Error())
 		}
 
-		err = printer.PrintReport(report, outputFormat)
+		err = printer.PrintReport(report, util.CreateFilter(filter), outputFormat)
 		if err != nil {
 			logrus.Errorf("failed to print report for profile %s: %s", profile, err.Error())
 		}

--- a/cmd/scrape-github.go
+++ b/cmd/scrape-github.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/chanzuckerberg/camelot/pkg/printer"
 	scraper "github.com/chanzuckerberg/camelot/pkg/scraper/github"
+	"github.com/chanzuckerberg/camelot/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -37,7 +38,7 @@ func scrapeGithub(ccmd *cobra.Command, args []string) error {
 	}
 	logrus.Debug("Scraping complete")
 
-	err = printer.PrintReport(report, outputFormat)
+	err = printer.PrintReport(report, util.CreateFilter(filter), outputFormat)
 	if err != nil {
 		return errors.Wrap(err, "failed to print report")
 	}

--- a/cmd/scrape-tfc.go
+++ b/cmd/scrape-tfc.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/chanzuckerberg/camelot/pkg/printer"
 	scraper "github.com/chanzuckerberg/camelot/pkg/scraper/tfc"
+	"github.com/chanzuckerberg/camelot/pkg/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -31,7 +32,7 @@ func scrapeTfc(ccmd *cobra.Command, args []string) error {
 	}
 	logrus.Debug("Scraping complete")
 
-	err = printer.PrintReport(report, outputFormat)
+	err = printer.PrintReport(report, util.CreateFilter(filter), outputFormat)
 	if err != nil {
 		return errors.Wrap(err, "failed to print report")
 	}

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	flagOutputFormat = "output"
+	flagFilter       = "filter"
 )
 
 var (
@@ -20,9 +21,11 @@ var (
 		},
 	}
 	outputFormat string
+	filter       string
 )
 
 func init() {
 	rootCmd.AddCommand(scrapeCmd)
 	scrapeCmd.PersistentFlags().StringVarP(&outputFormat, flagOutputFormat, "o", "text", "Output format (json, yaml, text). Defaults to text.")
+	scrapeCmd.PersistentFlags().StringVarP(&outputFormat, flagFilter, "f", "", "Report filter. Defaults to empty.")
 }

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -21,11 +21,11 @@ var (
 		},
 	}
 	outputFormat string
-	filter       string
+	filter       []string
 )
 
 func init() {
 	rootCmd.AddCommand(scrapeCmd)
 	scrapeCmd.PersistentFlags().StringVarP(&outputFormat, flagOutputFormat, "o", "text", "Output format (json, yaml, text). Defaults to text.")
-	scrapeCmd.PersistentFlags().StringVarP(&outputFormat, flagFilter, "f", "", "Report filter. Defaults to empty.")
+	scrapeCmd.PersistentFlags().StringSliceVarP(&filter, flagFilter, "f", []string{}, "Report filter. Defaults to empty.")
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -13,7 +13,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func PrintReport(report *types.InventoryReport, outputFormat string) error {
+func PrintReport(report *types.InventoryReport, filter util.ReportFilter, outputFormat string) error {
+	report = util.FilterReport(report, filter)
 	switch outputFormat {
 	case "json":
 		b, err := json.MarshalIndent(report, "", "  ")

--- a/pkg/scraper/aws/ami.go
+++ b/pkg/scraper/aws/ami.go
@@ -72,7 +72,7 @@ func extractAMIs(ctx context.Context, awsClient interfaces.AWSClient) (*types.In
 		for _, instance := range instances {
 			machineImages = append(machineImages, types.MachineImage{
 				VersionedResource: types.VersionedResource{
-					Name:           *image.ImageId,
+					ID:             *image.ImageId,
 					Kind:           types.KindMachineImage,
 					Parents:        []types.ParentResource{{Kind: types.KindEC2Instance, ID: *instance.InstanceId}},
 					Arn:            "",

--- a/pkg/scraper/aws/ami.go
+++ b/pkg/scraper/aws/ami.go
@@ -73,6 +73,7 @@ func extractAMIs(ctx context.Context, awsClient interfaces.AWSClient) (*types.In
 			machineImages = append(machineImages, types.MachineImage{
 				VersionedResource: types.VersionedResource{
 					Name:           *image.ImageId,
+					Kind:           types.KindMachineImage,
 					Parents:        []types.ParentResource{{Kind: types.KindEC2Instance, ID: *instance.InstanceId}},
 					Arn:            "",
 					Version:        *image.Name,

--- a/pkg/scraper/aws/eks.go
+++ b/pkg/scraper/aws/eks.go
@@ -115,6 +115,7 @@ func processCluster(ctx context.Context, awsClient interfaces.AWSClient, cluster
 	eksClusters := []types.EKSCluster{{
 		VersionedResource: types.VersionedResource{
 			Name:           *clusterInfo.Cluster.Name,
+			Kind:           types.KindEKSCluster,
 			Arn:            *clusterInfo.Cluster.Arn,
 			Parents:        []types.ParentResource{{Kind: types.KindAWSAccount, ID: awsClient.GetAccountId()}},
 			Version:        *clusterInfo.Cluster.Version,

--- a/pkg/scraper/aws/eks.go
+++ b/pkg/scraper/aws/eks.go
@@ -114,7 +114,7 @@ func processCluster(ctx context.Context, awsClient interfaces.AWSClient, cluster
 
 	eksClusters := []types.EKSCluster{{
 		VersionedResource: types.VersionedResource{
-			Name:           *clusterInfo.Cluster.Name,
+			ID:             *clusterInfo.Cluster.Name,
 			Kind:           types.KindEKSCluster,
 			Arn:            *clusterInfo.Cluster.Arn,
 			Parents:        []types.ParentResource{{Kind: types.KindAWSAccount, ID: awsClient.GetAccountId()}},

--- a/pkg/scraper/aws/helm.go
+++ b/pkg/scraper/aws/helm.go
@@ -84,6 +84,7 @@ func getHelmReleases(ctx context.Context, config *rest.Config, namespaces []stri
 			helmReleases = append(helmReleases, types.HelmRelease{
 				VersionedResource: types.VersionedResource{
 					Name:           fmt.Sprintf("%s/%s", namespace, release.Name),
+					Kind:           types.KindHelmRelease,
 					Arn:            "",
 					Parents:        []types.ParentResource{{Kind: types.KindEKSCluster, ID: clusterName}},
 					Version:        activeVersion.String(),

--- a/pkg/scraper/aws/lambda.go
+++ b/pkg/scraper/aws/lambda.go
@@ -55,7 +55,7 @@ func extractLambdas(ctx context.Context, awsClient interfaces.AWSClient) (*types
 		logrus.Debugf("lambda function: %s -> %s [%d]", *function.FunctionArn, function.Runtime, daysDiff)
 		lambdas = append(lambdas, types.Lambda{
 			VersionedResource: types.VersionedResource{
-				Name:           *function.FunctionName,
+				ID:             *function.FunctionName,
 				Kind:           types.KindLambda,
 				Parents:        []types.ParentResource{{Kind: types.KindAWSAccount, ID: awsClient.GetAccountId()}},
 				Arn:            *function.FunctionArn,

--- a/pkg/scraper/aws/lambda.go
+++ b/pkg/scraper/aws/lambda.go
@@ -56,6 +56,7 @@ func extractLambdas(ctx context.Context, awsClient interfaces.AWSClient) (*types
 		lambdas = append(lambdas, types.Lambda{
 			VersionedResource: types.VersionedResource{
 				Name:           *function.FunctionName,
+				Kind:           types.KindLambda,
 				Parents:        []types.ParentResource{{Kind: types.KindAWSAccount, ID: awsClient.GetAccountId()}},
 				Arn:            *function.FunctionArn,
 				Version:        version,

--- a/pkg/scraper/aws/rds.go
+++ b/pkg/scraper/aws/rds.go
@@ -63,7 +63,7 @@ func extractRds(ctx context.Context, awsClient interfaces.AWSClient) (*types.Inv
 		rdsClusters = append(rdsClusters, types.RDSCluster{
 			Engine: *instance.Engine,
 			VersionedResource: types.VersionedResource{
-				Name:           *instance.DBClusterIdentifier,
+				ID:             *instance.DBClusterIdentifier,
 				Kind:           types.KindRDSCluster,
 				Parents:        []types.ParentResource{{Kind: types.KindAWSAccount, ID: awsClient.GetAccountId()}},
 				Arn:            *instance.DBClusterArn,

--- a/pkg/scraper/aws/rds.go
+++ b/pkg/scraper/aws/rds.go
@@ -64,6 +64,7 @@ func extractRds(ctx context.Context, awsClient interfaces.AWSClient) (*types.Inv
 			Engine: *instance.Engine,
 			VersionedResource: types.VersionedResource{
 				Name:           *instance.DBClusterIdentifier,
+				Kind:           types.KindRDSCluster,
 				Parents:        []types.ParentResource{{Kind: types.KindAWSAccount, ID: awsClient.GetAccountId()}},
 				Arn:            *instance.DBClusterArn,
 				Version:        *instance.EngineVersion,

--- a/pkg/scraper/aws/util.go
+++ b/pkg/scraper/aws/util.go
@@ -28,16 +28,13 @@ func remainingDays(eol string) int {
 }
 
 func eolStatus(days int) types.Status {
-	if days <= 0 {
-		return types.StatusEndOfLife
-	}
 	if days <= 30 {
 		return types.StatusCritical
 	}
 	if days <= 90 {
 		return types.StatusWarning
 	}
-	return types.StatusActive
+	return types.StatusValid
 }
 
 func GetAWSProfiles() ([]string, error) {

--- a/pkg/scraper/aws/util_test.go
+++ b/pkg/scraper/aws/util_test.go
@@ -17,7 +17,7 @@ func TestRemainingDays(t *testing.T) {
 
 func TestEolStatus(t *testing.T) {
 	r := require.New(t)
-	r.Equal(types.StatusEndOfLife, string(eolStatus(0)))
+	r.Equal(types.StatusCritical, string(eolStatus(0)))
 	r.Equal(types.StatusCritical, string(eolStatus(15)))
 	r.Equal(types.StatusWarning, string(eolStatus(80)))
 }

--- a/pkg/scraper/github/scraper.go
+++ b/pkg/scraper/github/scraper.go
@@ -105,13 +105,13 @@ func Scrape(githubOrg string) (*types.InventoryReport, error) {
 		}
 
 		eolDate := date.AddDate(3, 0, 0)
-		var status types.Status = types.StatusActive
+		var status types.Status = types.StatusValid
 		if time.Now().After(eolDate) {
-			status = types.StatusOutdated
+			status = types.StatusWarning
 		}
 		report.Repos = append(report.Repos, types.GitRepo{
 			VersionedResource: types.VersionedResource{
-				Name:    *repo.Name,
+				ID:      *repo.Name,
 				Kind:    types.KindGithubRepo,
 				Arn:     "",
 				Parents: []types.ParentResource{{Kind: types.KindGithubOrg, ID: githubOrg}},
@@ -164,17 +164,17 @@ func Scrape(githubOrg string) (*types.InventoryReport, error) {
 		for index, ref := range moduleRefs {
 			repos := repoModuleReferenceMap[fmt.Sprintf("%s?ref=%s", module, ref.Ref)]
 			var status types.Status
-			status = types.StatusOutdated
+			status = types.StatusWarning
 			eolDate := ref.Timestamp.Format("2006-01-02")
 			if index == 0 {
-				status = types.StatusActive
+				status = types.StatusValid
 				// Assume modules are supported for 3 years
 				eolDate = ref.Timestamp.AddDate(3, 0, 0).Format("2006-01-02")
 			}
 			for repo := range repos {
 				report.Modules = append(report.Modules, types.TerraformModule{
 					VersionedResource: types.VersionedResource{
-						Name:           strings.Replace(module, fmt.Sprintf("github.com/%s/", githubOrg), "", 1),
+						ID:             strings.Replace(module, fmt.Sprintf("github.com/%s/", githubOrg), "", 1),
 						Kind:           types.KindTerrfaormModule,
 						Arn:            "",
 						Parents:        []types.ParentResource{{Kind: types.KindGithubRepo, ID: repo}},

--- a/pkg/scraper/github/scraper.go
+++ b/pkg/scraper/github/scraper.go
@@ -112,6 +112,7 @@ func Scrape(githubOrg string) (*types.InventoryReport, error) {
 		report.Repos = append(report.Repos, types.GitRepo{
 			VersionedResource: types.VersionedResource{
 				Name:    *repo.Name,
+				Kind:    types.KindGithubRepo,
 				Arn:     "",
 				Parents: []types.ParentResource{{Kind: types.KindGithubOrg, ID: githubOrg}},
 				Version: "0.0.0",
@@ -174,6 +175,7 @@ func Scrape(githubOrg string) (*types.InventoryReport, error) {
 				report.Modules = append(report.Modules, types.TerraformModule{
 					VersionedResource: types.VersionedResource{
 						Name:           strings.Replace(module, fmt.Sprintf("github.com/%s/", githubOrg), "", 1),
+						Kind:           types.KindTerrfaormModule,
 						Arn:            "",
 						Parents:        []types.ParentResource{{Kind: types.KindGithubRepo, ID: repo}},
 						Version:        ref.Ref,

--- a/pkg/scraper/tfc/scraper.go
+++ b/pkg/scraper/tfc/scraper.go
@@ -32,14 +32,14 @@ func Scrape() (*types.InventoryReport, error) {
 		for _, workspace := range workspaces {
 			eolDate := workspace.UpdatedAt.AddDate(0, 3, 0)
 
-			var status types.Status = types.StatusActive
+			var status types.Status = types.StatusValid
 			if time.Now().After(eolDate) {
-				status = types.StatusOutdated
+				status = types.StatusWarning
 			}
 
 			resource := types.TfcWorkspace{
 				VersionedResource: types.VersionedResource{
-					Name:    workspace.Name,
+					ID:      workspace.Name,
 					Kind:    types.KindTFCWorkspace,
 					Parents: []types.ParentResource{{Kind: types.KindTFCOrg, ID: org}},
 					Version: workspace.TerraformVersion,
@@ -69,7 +69,7 @@ func Scrape() (*types.InventoryReport, error) {
 		for i, tfcWorkspace := range report.TfcWorkspaces {
 			v, err := version.NewVersion(tfcWorkspace.Version)
 			if err == nil && v.LessThan(mostPopularVersion) {
-				report.TfcWorkspaces[i].EOL.Status = types.StatusOutdated
+				report.TfcWorkspaces[i].EOL.Status = types.StatusWarning
 			}
 		}
 	}
@@ -83,7 +83,7 @@ func Scrape() (*types.InventoryReport, error) {
 							if branch == "" {
 								branch = "main"
 							}
-							var status types.Status = types.StatusActive
+							var status types.Status = types.StatusValid
 							parents := []types.ParentResource{{Kind: types.KindTFCWorkspace, ID: orgName + "/" + workspace}}
 							if len(asset.ARN.AccountID) > 0 {
 								parents = append(parents, types.ParentResource{Kind: types.KindAWSAccount, ID: asset.ARN.AccountID})
@@ -91,7 +91,7 @@ func Scrape() (*types.InventoryReport, error) {
 
 							report.TfcResources = append(report.TfcResources, types.TfcResource{
 								VersionedResource: types.VersionedResource{
-									Name:    asset.ARN.Service + ":" + asset.ARN.Resource,
+									ID:      asset.ARN.Service + ":" + asset.ARN.Resource,
 									Kind:    types.KindTFCResource,
 									Parents: parents,
 									GitOpsReference: types.GitOpsReference{

--- a/pkg/scraper/tfc/scraper.go
+++ b/pkg/scraper/tfc/scraper.go
@@ -40,6 +40,7 @@ func Scrape() (*types.InventoryReport, error) {
 			resource := types.TfcWorkspace{
 				VersionedResource: types.VersionedResource{
 					Name:    workspace.Name,
+					Kind:    types.KindTFCWorkspace,
 					Parents: []types.ParentResource{{Kind: types.KindTFCOrg, ID: org}},
 					Version: workspace.TerraformVersion,
 					GitOpsReference: types.GitOpsReference{
@@ -91,6 +92,7 @@ func Scrape() (*types.InventoryReport, error) {
 							report.TfcResources = append(report.TfcResources, types.TfcResource{
 								VersionedResource: types.VersionedResource{
 									Name:    asset.ARN.Service + ":" + asset.ARN.Resource,
+									Kind:    types.KindTFCResource,
 									Parents: parents,
 									GitOpsReference: types.GitOpsReference{
 										Repo:   repoUrl,

--- a/pkg/scraper/types/types.go
+++ b/pkg/scraper/types/types.go
@@ -12,11 +12,17 @@ type ResourceKind string
 
 const KindAWSAccount ResourceKind = "aws"
 const KindEC2Instance ResourceKind = "ec2"
+const KindMachineImage ResourceKind = "ami"
+const KindRDSCluster ResourceKind = "rds"
+const KindLambda ResourceKind = "lambda"
 const KindEKSCluster ResourceKind = "eks"
+const KindHelmRelease ResourceKind = "helm"
 const KindGithubOrg ResourceKind = "github-org"
 const KindGithubRepo ResourceKind = "github-repo"
+const KindTerrfaormModule ResourceKind = "tf-module"
 const KindTFCOrg ResourceKind = "tfc-org"
 const KindTFCWorkspace ResourceKind = "tfc-workspace"
+const KindTFCResource ResourceKind = "tfc-resource"
 
 type EOLStatus struct {
 	EOLDate       string `json:"eol_date,omitempty"`
@@ -36,6 +42,7 @@ type ParentResource struct {
 }
 
 type VersionedResource struct {
+	Kind            ResourceKind     `json:"kind,omitempty"`
 	Name            string           `json:"name,omitempty"`
 	Arn             string           `json:"arn,omitempty"`
 	Parents         []ParentResource `json:"parents,omitempty"`

--- a/pkg/scraper/types/types.go
+++ b/pkg/scraper/types/types.go
@@ -2,11 +2,9 @@ package types
 
 type Status string
 
-const StatusActive = "ACTIVE"
-const StatusEndOfLife = "ENDOFLIFE"
+const StatusValid = "VALID"
 const StatusWarning = "WARNING"
 const StatusCritical = "CRITICAL"
-const StatusOutdated = "OUTDATED"
 
 type ResourceKind string
 
@@ -38,12 +36,12 @@ type GitOpsReference struct {
 
 type ParentResource struct {
 	Kind ResourceKind `json:"kind,omitempty"`
-	ID   string       `json:"name,omitempty"`
+	ID   string       `json:"id,omitempty"`
 }
 
 type VersionedResource struct {
 	Kind            ResourceKind     `json:"kind,omitempty"`
-	Name            string           `json:"name,omitempty"`
+	ID              string           `json:"id,omitempty"`
 	Arn             string           `json:"arn,omitempty"`
 	Parents         []ParentResource `json:"parents,omitempty"`
 	Version         string           `json:"version,omitempty"`

--- a/pkg/util/reports.go
+++ b/pkg/util/reports.go
@@ -80,8 +80,96 @@ func CombineReports(reports []*types.InventoryReport) types.InventoryReport {
 		summary.MachineImages = append(summary.MachineImages, report.MachineImages...)
 		summary.TfcResources = append(summary.TfcResources, report.TfcResources...)
 		summary.TfcWorkspaces = append(summary.TfcWorkspaces, report.TfcWorkspaces...)
+		summary.Repos = append(summary.Repos, report.Repos...)
+		summary.Modules = append(summary.Modules, report.Modules...)
 	}
 	return summary
+}
+
+func FilterReport(report *types.InventoryReport, filter ReportFilter) *types.InventoryReport {
+	if report == nil {
+		return nil
+	}
+	filtered := types.InventoryReport{}
+
+	// TODO: this is a mess, refactor
+	for _, item := range report.EksClusters {
+		if isMatch(item.VersionedResource, filter) {
+			filtered.EksClusters = append(filtered.EksClusters, item)
+		}
+	}
+	for _, item := range report.RdsClusters {
+		if isMatch(item.VersionedResource, filter) {
+			filtered.RdsClusters = append(filtered.RdsClusters, item)
+		}
+	}
+	for _, item := range report.Lambdas {
+		if isMatch(item.VersionedResource, filter) {
+			filtered.Lambdas = append(filtered.Lambdas, item)
+		}
+	}
+	for _, item := range report.HelmReleases {
+		if isMatch(item.VersionedResource, filter) {
+			filtered.HelmReleases = append(filtered.HelmReleases, item)
+		}
+	}
+	for _, item := range report.MachineImages {
+		if isMatch(item.VersionedResource, filter) {
+			filtered.MachineImages = append(filtered.MachineImages, item)
+		}
+	}
+	for _, item := range report.TfcResources {
+		if isMatch(item.VersionedResource, filter) {
+			filtered.TfcResources = append(filtered.TfcResources, item)
+		}
+	}
+	for _, item := range report.TfcWorkspaces {
+		if isMatch(item.VersionedResource, filter) {
+			filtered.TfcWorkspaces = append(filtered.TfcWorkspaces, item)
+		}
+	}
+	for _, item := range report.Repos {
+		if isMatch(item.VersionedResource, filter) {
+			filtered.Repos = append(filtered.Repos, item)
+		}
+	}
+	for _, item := range report.Modules {
+		if isMatch(item.VersionedResource, filter) {
+			filtered.Modules = append(filtered.Modules, item)
+		}
+	}
+
+	return &filtered
+}
+
+func isMatch(item types.VersionedResource, filter ReportFilter) bool {
+	if len(filter.ResourceKinds) > 0 {
+		found := false
+		for _, kind := range filter.ResourceKinds {
+			if item.Kind == kind {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	if len(filter.ParentTypes) > 0 {
+		found := false
+		for _, parent := range item.Parents {
+			for _, kind := range filter.ParentTypes {
+				if parent.Kind == kind {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func truncate(s string, l int) string {
@@ -97,4 +185,9 @@ func RemainingDays(eolDate time.Time) int {
 		return 0
 	}
 	return int(diff.Hours() / 24)
+}
+
+func CreateFilter(f string) ReportFilter {
+	filter := ReportFilter{}
+	return filter
 }

--- a/pkg/util/reports.go
+++ b/pkg/util/reports.go
@@ -9,39 +9,44 @@ import (
 	"github.com/chanzuckerberg/camelot/pkg/scraper/types"
 )
 
+type ReportFilter struct {
+	ResourceKinds []types.ResourceKind
+	ParentTypes   []types.ResourceKind
+}
+
 func ReportToTable(report types.InventoryReport) [][]string {
 	var table [][]string
 	for _, item := range report.MachineImages {
-		table = append(table, versionedResourceToTableRow("AMI", item.VersionedResource))
+		table = append(table, versionedResourceToTableRow(item.VersionedResource))
 	}
 	for _, item := range report.RdsClusters {
-		table = append(table, versionedResourceToTableRow("RDS", item.VersionedResource))
+		table = append(table, versionedResourceToTableRow(item.VersionedResource))
 	}
 	for _, item := range report.EksClusters {
-		table = append(table, versionedResourceToTableRow("EKS", item.VersionedResource))
+		table = append(table, versionedResourceToTableRow(item.VersionedResource))
 	}
 	for _, item := range report.Lambdas {
-		table = append(table, versionedResourceToTableRow("Lambda", item.VersionedResource))
+		table = append(table, versionedResourceToTableRow(item.VersionedResource))
 	}
 	for _, item := range report.Repos {
-		table = append(table, versionedResourceToTableRow("GitRepo", item.VersionedResource))
+		table = append(table, versionedResourceToTableRow(item.VersionedResource))
 	}
 	for _, item := range report.Modules {
-		table = append(table, versionedResourceToTableRow("TfModule", item.VersionedResource))
+		table = append(table, versionedResourceToTableRow(item.VersionedResource))
 	}
 	for _, item := range report.HelmReleases {
-		table = append(table, versionedResourceToTableRow("HelmRelease", item.VersionedResource))
+		table = append(table, versionedResourceToTableRow(item.VersionedResource))
 	}
 	for _, item := range report.TfcResources {
-		table = append(table, versionedResourceToTableRow("TfcResource", item.VersionedResource))
+		table = append(table, versionedResourceToTableRow(item.VersionedResource))
 	}
 	for _, item := range report.TfcWorkspaces {
-		table = append(table, versionedResourceToTableRow("TfcWorkspace", item.VersionedResource))
+		table = append(table, versionedResourceToTableRow(item.VersionedResource))
 	}
 	return table
 }
 
-func versionedResourceToTableRow(kind string, item types.VersionedResource) []string {
+func versionedResourceToTableRow(item types.VersionedResource) []string {
 	var sb strings.Builder
 	for _, p := range item.Parents {
 		if sb.Len() > 0 {
@@ -52,7 +57,7 @@ func versionedResourceToTableRow(kind string, item types.VersionedResource) []st
 		sb.WriteString(p.ID)
 	}
 	return []string{
-		kind,
+		string(item.Kind),
 		truncate(item.Name, 80),
 		truncate(sb.String(), 80),
 		item.Version,

--- a/pkg/util/reports_test.go
+++ b/pkg/util/reports_test.go
@@ -32,6 +32,8 @@ func TestCreateFilter(t *testing.T) {
 	r.True(f.ParentIDs[0] == "123456789012")
 	r.True(f.IDs[0] == "abc")
 
-	f = CreateFilter([]string{"status=active"})
-	r.True(f.Status == types.StatusActive)
+	f = CreateFilter([]string{"status=active,warning"})
+	r.True(len(f.Status) == 2)
+	r.True(f.Status[0] == types.StatusValid)
+	r.True(f.Status[1] == types.StatusWarning)
 }

--- a/pkg/util/reports_test.go
+++ b/pkg/util/reports_test.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/chanzuckerberg/camelot/pkg/scraper/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateFilter(t *testing.T) {
+	r := require.New(t)
+	f := CreateFilter([]string{"kind=" + string(types.KindEKSCluster)})
+	r.True(len(f.ResourceKinds) == 1)
+	r.True(f.ResourceKinds[0] == types.KindEKSCluster)
+
+	f = CreateFilter([]string{"parent.kind=" + string(types.KindEKSCluster)})
+	r.True(len(f.ParentKinds) == 1)
+	r.True(f.ParentKinds[0] == types.KindEKSCluster)
+
+	f = CreateFilter([]string{"parent.kind=" + string(types.KindAWSAccount), "parent.id=123456789012"})
+	r.True(len(f.ParentKinds) == 1)
+	r.True(len(f.ParentIDs) == 1)
+	r.True(len(f.IDs) == 0)
+	r.True(f.ParentKinds[0] == types.KindAWSAccount)
+	r.True(f.ParentIDs[0] == "123456789012")
+
+	f = CreateFilter([]string{"parent.kind=" + string(types.KindAWSAccount), "parent.id=123456789012", "id=abc"})
+	r.True(len(f.ParentKinds) == 1)
+	r.True(len(f.ParentIDs) == 1)
+	r.True(len(f.IDs) == 1)
+	r.True(f.ParentKinds[0] == types.KindAWSAccount)
+	r.True(f.ParentIDs[0] == "123456789012")
+	r.True(f.IDs[0] == "abc")
+
+	f = CreateFilter([]string{"status=active"})
+	r.True(f.Status == types.StatusActive)
+}

--- a/pkg/util/reports_test.go
+++ b/pkg/util/reports_test.go
@@ -32,7 +32,7 @@ func TestCreateFilter(t *testing.T) {
 	r.True(f.ParentIDs[0] == "123456789012")
 	r.True(f.IDs[0] == "abc")
 
-	f = CreateFilter([]string{"status=active,warning"})
+	f = CreateFilter([]string{"status=valid,warning"})
 	r.True(len(f.Status) == 2)
 	r.True(f.Status[0] == types.StatusValid)
 	r.True(f.Status[1] == types.StatusWarning)


### PR DESCRIPTION
Support for basic cli-level filters on inventory reports. Queries look like 

```sh
camelot scrape tfc -f kind=tfc-workspace -f parent.kind=tfc-org -f parent.id=my-infra -f status=warning,critical -f version=0.13.5
```