### PR TITLE
chore: Tweaking release-please-settings

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -23,4 +23,7 @@ jobs:
           with:
             release-type: simple
             token: ${{ steps.generate_token.outputs.token }}
+            pull-request-title-pattern: "chore${scope}: release${component} ${version}"
+            changelog-types: '[ { "type": "feat", "section": "Features", "hidden": false }, { "type": "fix", "section": "Bug fixes", "hidden": false }, { "type": "build", "section": "Dependencies", "hidden": false }, { "type": "chore", "section": "Miscellaneous", "hidden": false }, { "type": "ci", "section": "Continuous integration", "hidden": false }, { "type": "perf", "section": "Improvements", "hidden": false }, { "type": "refactor", "section": "Improvements", "hidden": false }, { "type": "style", "section": "Miscellaneous", "hidden": false }, { "type": "docs", "section": "Documentation", "hidden": false }]'
+
  


### PR DESCRIPTION
release-please seems to ignore the config, as chores are always excluded