### PR TITLE
fix: Update runs-on labels in GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ on: pull_request
 
 jobs:
   lint:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
@@ -17,7 +17,7 @@ jobs:
           working-directory: .
           skip-pkg-cache: true
   test:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3

--- a/.github/workflows/conventional_commits_title.yaml
+++ b/.github/workflows/conventional_commits_title.yaml
@@ -11,6 +11,6 @@ on:
 
 jobs:
     conventional_commit_title:
-      runs-on: [ARM64, self-hosted, Linux]
+      runs-on: ARM64
       steps:
         - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@v1.3.1

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -9,7 +9,7 @@ concurrency:
     cancel-in-progress: true
 jobs:
   dependabot-automerge:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ARM64
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Generate token

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -6,7 +6,7 @@ on:
 name: release-please
 jobs:
     release-please:
-      runs-on: [ARM64, self-hosted, Linux]
+      runs-on: ARM64
       steps:
         # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
         # For why we need to generate a token and not use the default

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
 name: release
 jobs:
     release:
-      runs-on: [ARM64, self-hosted, Linux]
+      runs-on: ARM64
       steps:
         # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
         # For why we need to generate a token and not use the default


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-3911

This PR updates 'runs-on' in GitHub Actions workflow files to use direct values instead of label arrays.