### PR TITLE
fix: Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,9 @@ on: pull_request
 jobs:
   lint:
     runs-on: ARM64
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
@@ -18,6 +21,8 @@ jobs:
           skip-pkg-cache: true
   test:
     runs-on: ARM64
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3


### PR DESCRIPTION
Potential fix for [https://github.com/chanzuckerberg/camelot/security/code-scanning/1](https://github.com/chanzuckerberg/camelot/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the jobs to function correctly. Based on the workflow's tasks:
- The `lint` job requires read access to repository contents and possibly write access to pull requests (if it comments on PRs).
- The `test` job only requires read access to repository contents.

The `permissions` block can be added at the root level to apply to all jobs or individually for each job. In this case, adding permissions at the job level provides better granularity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
