### PR TITLE
fix: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -4,6 +4,9 @@ on:
         - main
   
 name: release-please
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
     release-please:
       runs-on: ARM64


### PR DESCRIPTION
Potential fix for [https://github.com/chanzuckerberg/camelot/security/code-scanning/2](https://github.com/chanzuckerberg/camelot/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, it appears that the workflow interacts with pull requests and uses the `contents` scope. Therefore, we will set `contents: read` and `pull-requests: write` as the permissions. This ensures that the workflow has only the necessary access to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
