### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/conventional_commits_title.yaml
+++ b/.github/workflows/conventional_commits_title.yaml
@@ -1,5 +1,8 @@
 # Validates PR title follows conventional commits
 name: conventional-commits
+permissions:
+  contents: read
+  pull-requests: read
 on:
   pull_request:
     branches: main


### PR DESCRIPTION
Potential fix for [https://github.com/chanzuckerberg/camelot/security/code-scanning/3](https://github.com/chanzuckerberg/camelot/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's purpose (validating PR titles), it likely only needs `contents: read` and possibly `pull-requests: read`. We will set these permissions explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
