### PR TITLE
fix: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,8 @@
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ARM64


### PR DESCRIPTION
Potential fix for [https://github.com/chanzuckerberg/camelot/security/code-scanning/4](https://github.com/chanzuckerberg/camelot/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient for the `lint` and `test` jobs, as they only involve checking out the repository and running commands without modifying repository contents. 

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
