### PR TITLE
fix: Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
     types: [published]
   
 name: release
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
     release:
       runs-on: ARM64


### PR DESCRIPTION
Potential fix for [https://github.com/chanzuckerberg/camelot/security/code-scanning/5](https://github.com/chanzuckerberg/camelot/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the provided steps, the workflow requires `contents: read` to fetch the repository contents and `contents: write` to perform the release. Additionally, the `pull-requests: write` permission might be necessary if the workflow interacts with pull requests. We will set these permissions explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
